### PR TITLE
[Wendy] react18버전 이전과 이후의 차이

### DIFF
--- a/CS면접/Wendy/React/react 18이전 이후 차이점
+++ b/CS면접/Wendy/React/react 18이전 이후 차이점
@@ -1,0 +1,25 @@
+# automatic batching
+
+-   배칭: 여러상태 업데이트를 한번에 모아 처리하는방식
+-   18버전이 되면서 네트워크 요청내에서 발생하는 여러 상태 업데이트도 하나의 렌더링으로 처리가능
+-   18버전 이후에도 배칭이 존재했지만 , 18버전 이후에는 클릭과 같은 브라우저 이벤트에서만 작동 되었고 api호출시 콜백에서는 작동되지 않았음
+
+# useTransition
+
+-   상테 업데이트에 대한 우선순위를 정해줄수있음
+
+```jsx
+import { startTransition } from "react";
+// Urgent: Show what was typed
+setInputValue(input);
+
+// Mark any state updates inside as transitions
+startTransition(() => {
+    // Transition: Show the results
+    setSearchQuery(input);
+});
+```
+
+-   startTransition으로 둘러싸인 부분은 클릭이나 키 입력에 의해 우선순위 높은 상태 업데이트가 발생하게 되면 렌더링 업데이트가 중단되고 키 입력이 다 끝난 이후의 업데이트만 발생.
+-   <Spinner/>와 같은 UI를 표시 가능
+-   즉 비동기 처리 작업시 작업의 진행상태를 알수있고, 로딩상태도 표시할수있음


### PR DESCRIPTION
<div align="end">
<h3> $\color{#2699E6}{🎤 면접관}$ </h3>

React의 18버전 업데이트 이전과 이후의 차이점에 대해 아시나요?

</div>

<br/>

<div align="start">
<h3>  $\color{#FFA832}{🤚 면접자}$ </h3>

리액트 18버전 업데이트 이후 바뀐점은 크게 두가지로 볼수있습니다
첫째 automatic batching입니다. 18버전 이전에도 여러상태 업데이트를 한꺼번에 처리하는 배칭 방식을 지원했으나 api  네트워크 요청내에서는 작동하지않았습니다. 그러나 업데이트 이후 네트워크 요청내에서 발생하는 여러상태 업데이트도 하나의 렌더링으로 처리가능해졌습니다.
둘째, usetransition 훅함수의 등장입니다. 이 훅함수는 비동기 처리 작업시 진행상태를 알수있고, 트랜지션이 진행중일때 유저에게 <Spinner/>와 같은 로딩상태를 표시해줄수있습니다.

</div>




